### PR TITLE
Olympians Endpoint

### DIFF
--- a/api/management/commands/import_csv.py
+++ b/api/management/commands/import_csv.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
       reader = csv.DictReader(csvfile)
       total_time = 0.
       dot_string = ''
-      
+
       for i, row in enumerate(reader):
         start = time.time()
         height = None if row['Height'] == 'NA' else int(row['Height'])
@@ -42,11 +42,12 @@ class Command(BaseCommand):
           medal=row['Medal']
         )
 
-        stop = time.time()
-        total_time += (stop - start)
         if i % 700 == 0 and i != 0:
           dot_string = dot_string + '.'
           print(dot_string)
+          
+        stop = time.time()
+        total_time += (stop - start)
 
     print(f'import_csv script has completed in {round(total_time, 2)} seconds')
 

--- a/api/management/commands/import_csv.py
+++ b/api/management/commands/import_csv.py
@@ -15,6 +15,7 @@ class Command(BaseCommand):
       reader = csv.DictReader(csvfile)
       total_time = 0.
       dot_string = ''
+      
       for i, row in enumerate(reader):
         start = time.time()
         height = None if row['Height'] == 'NA' else int(row['Height'])

--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,14 @@
 from django.db import models
+from django.db.models import Count, Q
 
+def _olympian_payload(olympian):
+  return {
+      'name': olympian.name,
+      'team': olympian.team,
+      'age': olympian.age,
+      'sport': olympian.sport,
+      'total_medals_won': olympian.medal_count
+  }
 
 class Olympian(models.Model):
   GENDER = [
@@ -19,6 +28,17 @@ class Olympian(models.Model):
 
   def __str__(self):
     return self.name
+  
+  @classmethod
+  def all_olympians(cls):
+    medals = ['Gold', 'Silver', 'Bronze']
+
+    olympians = Olympian.objects.annotate(
+        medal_count=Count('eventolympian__medal', filter=Q(eventolympian__medal__in=medals))
+    ).order_by('name')
+
+    return [_olympian_payload(olympian) for olympian in olympians]
+
     
 class Event(models.Model):
   name = models.CharField(max_length=100)

--- a/api/tests/factories.py
+++ b/api/tests/factories.py
@@ -1,0 +1,38 @@
+from .. import models
+from faker.factory import Factory
+import factory.fuzzy
+Faker = Factory.create
+fake = Faker()
+fake.seed(0)
+
+
+class OlympianFactory(factory.django.DjangoModelFactory):
+  class Meta:
+    model = models.Olympian
+
+  name = factory.Sequence(lambda n: 'Olympian %d' % n)
+  sex = factory.fuzzy.FuzzyChoice(['M', 'F'])
+  age = factory.fuzzy.FuzzyInteger(8, 70)
+  height = factory.fuzzy.FuzzyInteger(100, 210)
+  weight = factory.fuzzy.FuzzyInteger(30, 120)
+  team = fake.country()
+  sport = fake.sentence(nb_words=3, variable_nb_words=True)
+
+
+class EventFactory(factory.django.DjangoModelFactory):
+  class Meta:
+    model = models.Event
+
+  name = factory.Sequence(lambda n: 'Event %d' % n)
+  games = '2016 Summer'
+  sport = fake.sentence(nb_words=4, variable_nb_words=True)
+
+
+class EventOlympianFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.EventOlympian
+
+    event = factory.SubFactory(EventFactory)
+    olympian = factory.SubFactory(OlympianFactory)
+    medal = factory.fuzzy.FuzzyChoice(['Gold', 'Silver', 'Bronze'])
+

--- a/api/tests/models/test_olympian.py
+++ b/api/tests/models/test_olympian.py
@@ -1,12 +1,54 @@
 from django.test import TestCase
 from api.models import Olympian
+from ..factories import OlympianFactory, EventFactory, EventOlympianFactory
 
 
 class OlympianModelTest(TestCase):
   def setUp(self):
-    self.olympian1 = Olympian.objects.create(name='olympian1', sex='M', age=30, height=160, weight=55, team='Spain', sport='Gymnastics')
+    self.olympian1 = OlympianFactory(name='Curtis')
+    self.olympian2 = OlympianFactory(name='Albert')
+    self.olympian3 = OlympianFactory(name='Billy')
+
+    self.event1 = EventFactory()
+    self.event2 = EventFactory()
+
+    self.event_olympian1 = EventOlympianFactory(event=self.event1, olympian=self.olympian1, medal='NA')
+    self.event_olympian2 = EventOlympianFactory(event=self.event2, olympian=self.olympian1, medal='Bronze')
+
+    self.event_olympian3 = EventOlympianFactory(event=self.event1, olympian=self.olympian2, medal='Silver')
+    self.event_olympian4 = EventOlympianFactory(event=self.event2, olympian=self.olympian2, medal='Silver')
+
+    self.event_olympian5 = EventOlympianFactory(event=self.event1, olympian=self.olympian3, medal='NA')
+    self.event_olympian6 = EventOlympianFactory(event=self.event2, olympian=self.olympian3, medal='NA')
 
   def test_string_representation(self):
     self.assertEqual(str(self.olympian1), self.olympian1.name)
+
+  def test_all_olympians(self):
+    expected = [
+      {
+          'name': self.olympian2.name,
+          'team': self.olympian2.team,
+          'age': self.olympian2.age,
+          'sport': self.olympian2.sport,
+          'total_medals_won': 2
+      },
+      {
+          'name': self.olympian3.name,
+          'team': self.olympian3.team,
+          'age': self.olympian3.age,
+          'sport': self.olympian3.sport,
+          'total_medals_won': 0
+      },
+      {
+          'name': self.olympian1.name,
+          'team': self.olympian1.team,
+          'age': self.olympian1.age,
+          'sport': self.olympian1.sport,
+          'total_medals_won': 1
+      }
+    ]
+    
+    self.assertEqual(Olympian.all_olympians(), expected)
 
 

--- a/api/tests/views/test_olympian_views.py
+++ b/api/tests/views/test_olympian_views.py
@@ -25,6 +25,8 @@ class OlympianViewSet(TestCase):
   def test_happy_path_get_all_olympians(self):
     response = self.client.get('/api/v1/olympians')
 
+    json_response = response.json()
+
     expected = {
       'olympians': [
         {
@@ -52,4 +54,4 @@ class OlympianViewSet(TestCase):
     }
 
     self.assertEqual(response.status_code, 200)
-    self.assertEqual(response.data, expected)
+    self.assertEqual(json_response, expected)

--- a/api/tests/views/test_olympian_views.py
+++ b/api/tests/views/test_olympian_views.py
@@ -1,0 +1,55 @@
+import json
+from django.test import TestCase
+from ..factories import OlympianFactory, EventFactory, EventOlympianFactory
+
+
+class OlympianViewSet(TestCase):
+  def setUp(self):
+    self.olympian1 = OlympianFactory(name='Curtis')
+    self.olympian2 = OlympianFactory(name='Albert')
+    self.olympian3 = OlympianFactory(name='Billy')
+
+    self.event1 = EventFactory()
+    self.event2 = EventFactory()
+
+    self.event_olympian1 = EventOlympianFactory(event=self.event1, olympian=self.olympian1, medal='NA')
+    self.event_olympian2 = EventOlympianFactory(event=self.event2, olympian=self.olympian1, medal='Bronze')
+
+    self.event_olympian3 = EventOlympianFactory(event=self.event1, olympian=self.olympian2, medal='Silver')
+    self.event_olympian4 = EventOlympianFactory(event=self.event2, olympian=self.olympian2, medal='Silver')
+
+    self.event_olympian5 = EventOlympianFactory(event=self.event1, olympian=self.olympian3, medal='NA')
+    self.event_olympian6 = EventOlympianFactory(event=self.event2, olympian=self.olympian3, medal='NA')
+
+
+  def test_happy_path_get_all_olympians(self):
+    response = self.client.get('/api/v1/olympians')
+
+    expected = {
+      'olympians': [
+        {
+          'name': self.olympian2.name,
+          'team': self.olympian2.team,
+          'age': self.olympian2.age,
+          'sport': self.olympian2.sport,
+          'total_medals_won': 2
+        },
+        {
+          'name': self.olympian3.name,
+          'team': self.olympian3.team,
+          'age': self.olympian3.age,
+          'sport': self.olympian3.sport,
+          'total_medals_won': 0
+        },
+        {
+          'name': self.olympian1.name,
+          'team': self.olympian1.team,
+          'age': self.olympian1.age,
+          'sport': self.olympian1.sport,
+          'total_medals_won': 1
+        }
+      ]
+    }
+
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(response.data, expected)

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,40 @@
+import json
 from django.shortcuts import render
+from django.http import JsonResponse
+from django.http import HttpResponse
+from rest_framework.views import APIView
+# from django.contrib.auth.models import User
+# from django.core.exceptions import ObjectDoesNotExist
 
-# Create your views here.
+
+def _error_payload(error, code=400):
+  return {
+      'success': False,
+      'error': code,
+      'errors': error
+  }
+
+def _olympian_payload(olympians):
+  return {
+      'olympians': olympians
+    }
+
+class OlympianList(APIView):
+  def get(self, request):
+
+    # Build a custom Olympian class function that
+    # Pulls out all olympians from the db, including their total
+    # medal count
+    # This method must turn an array of hashes
+
+    # Total medal count will have to be caluclated with join
+    # to event_olympian table and counting medals
+    
+    if request.GET['age']:
+      ''
+    else:
+      import code; code.interact(local=dict(globals(), **locals()))
+      ''
+
+    return JsonResponse(_error_payload, status=400)
+

--- a/api/views.py
+++ b/api/views.py
@@ -22,20 +22,9 @@ def _olympians_payload(olympians):
 
 class OlympianList(APIView):
   def get(self, request):
-    # Build a custom Olympian class function that
-    # Pulls out all olympians from the db, including their total
-    # medal count
-    # This method must turn an array of hashes
-
-    # Total medal count will have to be caluclated with join
-    # to event_olympian table and counting medals
-    
-    # if request.GET['age']:
-    #   ''
-    # else:
     olympians = Olympian.all_olympians()
+    
     return JsonResponse(_olympians_payload(olympians), status=200)
 
 
-    # return JsonResponse(_error_payload(error), status=400)
 

--- a/api/views.py
+++ b/api/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import render
 from django.http import JsonResponse
 from django.http import HttpResponse
 from rest_framework.views import APIView
+from api.models import Olympian
 # from django.contrib.auth.models import User
 # from django.core.exceptions import ObjectDoesNotExist
 
@@ -14,14 +15,13 @@ def _error_payload(error, code=400):
       'errors': error
   }
 
-def _olympian_payload(olympians):
+def _olympians_payload(olympians):
   return {
       'olympians': olympians
-    }
+  }
 
 class OlympianList(APIView):
   def get(self, request):
-
     # Build a custom Olympian class function that
     # Pulls out all olympians from the db, including their total
     # medal count
@@ -30,11 +30,12 @@ class OlympianList(APIView):
     # Total medal count will have to be caluclated with join
     # to event_olympian table and counting medals
     
-    if request.GET['age']:
-      ''
-    else:
-      import code; code.interact(local=dict(globals(), **locals()))
-      ''
+    # if request.GET['age']:
+    #   ''
+    # else:
+    olympians = Olympian.all_olympians()
+    return JsonResponse(_olympians_payload(olympians), status=200)
 
-    return JsonResponse(_error_payload, status=400)
+
+    # return JsonResponse(_error_payload(error), status=400)
 

--- a/olympic_analytics_tracker/urls.py
+++ b/olympic_analytics_tracker/urls.py
@@ -15,7 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from api import views
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/v1/olympians', views.OlympianList.as_view()),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ coverage==5.3
 dj-database-url==0.5.0
 Django==2.2.17
 django-heroku==0.3.1
+djangorestframework==3.12.2
 factory-boy==3.1.0
 Faker==4.16.0
 gunicorn==20.0.4


### PR DESCRIPTION
## Description
- Create factories for all models
- Create `GET api/v1/olympians` endpoint that returns information for all Olympians in the 2016 summer games.

Response example:
```
{
  "olympians":
    [
      {
        "name": "Maha Abdalsalam",
        "team": "Egypt",
        "age": 18,
        "sport": "Diving"
        "total_medals_won": 0
      },
      {
        "name": "Ahmad Abughaush",
        "team": "Jordan",
        "age": 20,
        "sport": "Taekwondo"
        "total_medals_won": 1
      },
      {...}
    ]
}
```

Completes User Story #8 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Unittest Results
- 100%
