### PR TITLE
#9 and #10 - Youngest and Oldest Olympians Endpoints

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -51,7 +51,6 @@ class Olympian(models.Model):
     return [_olympian_payload(olympian) for olympian in olympians]
 
 
-
 class Event(models.Model):
   name = models.CharField(max_length=100)
   games = models.CharField(max_length=100)

--- a/api/models.py
+++ b/api/models.py
@@ -39,7 +39,19 @@ class Olympian(models.Model):
 
     return [_olympian_payload(olympian) for olympian in olympians]
 
-    
+  @classmethod
+  def youngest_oldest_olympian(cls, age):
+    order = 'age' if age == 'youngest' else '-age'
+    medals = ['Gold', 'Silver', 'Bronze']
+
+    olympians = Olympian.objects.annotate(
+        medal_count=Count('eventolympian__medal', filter=Q(eventolympian__medal__in=medals))
+    ).order_by(order)[:1]
+
+    return [_olympian_payload(olympian) for olympian in olympians]
+
+
+
 class Event(models.Model):
   name = models.CharField(max_length=100)
   games = models.CharField(max_length=100)

--- a/api/tests/models/test_olympian.py
+++ b/api/tests/models/test_olympian.py
@@ -51,7 +51,7 @@ class OlympianModelTest(TestCase):
     
     self.assertEqual(Olympian.all_olympians(), expected)
 
-  def test_youngest_olympian(self):
+  def test_youngest_oldest_olympian(self):
     expected_youngest = [
       {
           'name': self.olympian2.name,

--- a/api/tests/models/test_olympian.py
+++ b/api/tests/models/test_olympian.py
@@ -5,9 +5,9 @@ from ..factories import OlympianFactory, EventFactory, EventOlympianFactory
 
 class OlympianModelTest(TestCase):
   def setUp(self):
-    self.olympian1 = OlympianFactory(name='Curtis')
-    self.olympian2 = OlympianFactory(name='Albert')
-    self.olympian3 = OlympianFactory(name='Billy')
+    self.olympian1 = OlympianFactory(name='Curtis', age=22)
+    self.olympian2 = OlympianFactory(name='Albert', age=19)
+    self.olympian3 = OlympianFactory(name='Billy', age=30)
 
     self.event1 = EventFactory()
     self.event2 = EventFactory()
@@ -50,5 +50,29 @@ class OlympianModelTest(TestCase):
     ]
     
     self.assertEqual(Olympian.all_olympians(), expected)
+
+  def test_youngest_olympian(self):
+    expected_youngest = [
+      {
+          'name': self.olympian2.name,
+          'team': self.olympian2.team,
+          'age': self.olympian2.age,
+          'sport': self.olympian2.sport,
+          'total_medals_won': 2
+      }
+    ]
+
+    expected_oldest = [
+      {
+          'name': self.olympian3.name,
+          'team': self.olympian3.team,
+          'age': self.olympian3.age,
+          'sport': self.olympian3.sport,
+          'total_medals_won': 0
+      }
+    ]
+    
+    self.assertEqual(Olympian.youngest_oldest_olympian('youngest'), expected_youngest)
+    self.assertEqual(Olympian.youngest_oldest_olympian('oldest'), expected_oldest)
 
 

--- a/api/tests/views/test_olympian_views.py
+++ b/api/tests/views/test_olympian_views.py
@@ -75,3 +75,23 @@ class OlympianViewSet(TestCase):
 
     self.assertEqual(response.status_code, 200)
     self.assertEqual(json_response, expected)
+
+  def test_happy_path_get_oldest_olympian(self):
+    response = self.client.get('/api/v1/olympians?age=oldest')
+
+    json_response = response.json()
+
+    expected = {
+      'olympians': [
+        {
+          'name': self.olympian3.name,
+          'team': self.olympian3.team,
+          'age': self.olympian3.age,
+          'sport': self.olympian3.sport,
+          'total_medals_won': 0
+        }
+      ]
+    }
+
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(json_response, expected)

--- a/api/tests/views/test_olympian_views.py
+++ b/api/tests/views/test_olympian_views.py
@@ -5,9 +5,9 @@ from ..factories import OlympianFactory, EventFactory, EventOlympianFactory
 
 class OlympianViewSet(TestCase):
   def setUp(self):
-    self.olympian1 = OlympianFactory(name='Curtis')
-    self.olympian2 = OlympianFactory(name='Albert')
-    self.olympian3 = OlympianFactory(name='Billy')
+    self.olympian1 = OlympianFactory(name='Curtis', age=22)
+    self.olympian2 = OlympianFactory(name='Albert', age=19)
+    self.olympian3 = OlympianFactory(name='Billy', age=30)
 
     self.event1 = EventFactory()
     self.event2 = EventFactory()
@@ -49,6 +49,26 @@ class OlympianViewSet(TestCase):
           'age': self.olympian1.age,
           'sport': self.olympian1.sport,
           'total_medals_won': 1
+        }
+      ]
+    }
+
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(json_response, expected)
+
+  def test_happy_path_get_youngest_olympian(self):
+    response = self.client.get('/api/v1/olympians?age=youngest')
+
+    json_response = response.json()
+
+    expected = {
+      'olympians': [
+        {
+          'name': self.olympian2.name,
+          'team': self.olympian2.team,
+          'age': self.olympian2.age,
+          'sport': self.olympian2.sport,
+          'total_medals_won': 2
         }
       ]
     }

--- a/api/views.py
+++ b/api/views.py
@@ -1,11 +1,8 @@
 import json
 from django.shortcuts import render
-from django.http import JsonResponse
-from django.http import HttpResponse
+from django.http import JsonResponse, HttpResponse, QueryDict
 from rest_framework.views import APIView
 from api.models import Olympian
-# from django.contrib.auth.models import User
-# from django.core.exceptions import ObjectDoesNotExist
 
 
 def _error_payload(error, code=400):
@@ -22,9 +19,16 @@ def _olympians_payload(olympians):
 
 class OlympianList(APIView):
   def get(self, request):
-    olympians = Olympian.all_olympians()
+    params = request.GET
+
+    if params.__contains__('age'):
+      olympians = Olympian.youngest_oldest_olympian(params['age'])
+
+      return JsonResponse(_olympians_payload(olympians), status=200)
+    else:
+      olympians = Olympian.all_olympians()
     
-    return JsonResponse(_olympians_payload(olympians), status=200)
+      return JsonResponse(_olympians_payload(olympians), status=200)
 
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -23,12 +23,11 @@ class OlympianList(APIView):
 
     if params.__contains__('age'):
       olympians = Olympian.youngest_oldest_olympian(params['age'])
-
-      return JsonResponse(_olympians_payload(olympians), status=200)
     else:
       olympians = Olympian.all_olympians()
     
-      return JsonResponse(_olympians_payload(olympians), status=200)
+    return JsonResponse(_olympians_payload(olympians), status=200)
+
 
 
 


### PR DESCRIPTION
## Description
- The `GET api/v1/olympians` endpoint now accepts an `?age=youngest` or `?age=oldest` query parameter which returns either the youngest or oldest olympian

Response Example:
```
{
  "olympians":
    [
      {
        "name": "Ana Iulia Dascl",
        "team": "Romania",
        "age": 13,
        "sport": "Swimming"
        "total_medals_won": 0
      }
    ]
}
```

Completes User Stories #9,  #10 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Unittest Results
- 100% - 8 passing
