### PR TITLE
Issue #11 - Olympian Stats

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.db.models import Count, Q
+from django.db.models import Count, Avg, Q
 
 def _olympian_payload(olympian):
   return {
@@ -49,6 +49,15 @@ class Olympian(models.Model):
     ).order_by(order)[:1]
 
     return [_olympian_payload(olympian) for olympian in olympians]
+
+  @classmethod
+  def olympian_stats(cls):
+    return Olympian.objects.aggregate(
+        total_olympians=Count('id'),
+        avg_age=Avg('age'),
+        male_avg=Avg('weight', filter=Q(sex='M')),
+        female_avg=Avg('weight', filter=Q(sex='F'))
+    )
 
 
 class Event(models.Model):

--- a/api/tests/models/test_olympian.py
+++ b/api/tests/models/test_olympian.py
@@ -5,9 +5,9 @@ from ..factories import OlympianFactory, EventFactory, EventOlympianFactory
 
 class OlympianModelTest(TestCase):
   def setUp(self):
-    self.olympian1 = OlympianFactory(name='Curtis', age=22)
-    self.olympian2 = OlympianFactory(name='Albert', age=19)
-    self.olympian3 = OlympianFactory(name='Billy', age=30)
+    self.olympian1 = OlympianFactory(name='Curtis', age=22, sex='M', weight=123)
+    self.olympian2 = OlympianFactory(name='Albert', age=19, sex='F', weight=150)
+    self.olympian3 = OlympianFactory(name='Billy', age=30, sex='M', weight=208)
 
     self.event1 = EventFactory()
     self.event2 = EventFactory()
@@ -74,5 +74,16 @@ class OlympianModelTest(TestCase):
     
     self.assertEqual(Olympian.youngest_oldest_olympian('youngest'), expected_youngest)
     self.assertEqual(Olympian.youngest_oldest_olympian('oldest'), expected_oldest)
+
+  def test_olympian_stats(self):
+
+    expected = {
+      'total_olympians': 3, 
+      'avg_age': 23.666666666666668,
+      'male_avg': 165.5, 
+      'female_avg': 150.0
+    }
+
+    self.assertEqual(Olympian.olympian_stats(), expected)
 
 

--- a/api/tests/views/test_olympian_views.py
+++ b/api/tests/views/test_olympian_views.py
@@ -5,9 +5,9 @@ from ..factories import OlympianFactory, EventFactory, EventOlympianFactory
 
 class OlympianViewSet(TestCase):
   def setUp(self):
-    self.olympian1 = OlympianFactory(name='Curtis', age=22, sex='M', weight=100)
-    self.olympian2 = OlympianFactory(name='Albert', age=19, sex='F', weight=150.5)
-    self.olympian3 = OlympianFactory(name='Billy', age=30, sex='M', weight=200)
+    self.olympian1 = OlympianFactory(name='Curtis', age=22, sex='M', weight=123)
+    self.olympian2 = OlympianFactory(name='Albert', age=19, sex='F', weight=150)
+    self.olympian3 = OlympianFactory(name='Billy', age=30, sex='M', weight=208)
 
     self.event1 = EventFactory()
     self.event2 = EventFactory()
@@ -106,8 +106,8 @@ class OlympianViewSet(TestCase):
         'total_competing_olympians': 3,
         'average_weight': {
           'unit': 'kg',
-          'male_olympians': 150.0,
-          'female_olympians': 150.5
+          'male_olympians': 165.5,
+          'female_olympians': 150.0
         },
         'average_age': 23.7
       }

--- a/api/tests/views/test_olympian_views.py
+++ b/api/tests/views/test_olympian_views.py
@@ -5,9 +5,9 @@ from ..factories import OlympianFactory, EventFactory, EventOlympianFactory
 
 class OlympianViewSet(TestCase):
   def setUp(self):
-    self.olympian1 = OlympianFactory(name='Curtis', age=22)
-    self.olympian2 = OlympianFactory(name='Albert', age=19)
-    self.olympian3 = OlympianFactory(name='Billy', age=30)
+    self.olympian1 = OlympianFactory(name='Curtis', age=22, sex='M', weight=100)
+    self.olympian2 = OlympianFactory(name='Albert', age=19, sex='F', weight=150.5)
+    self.olympian3 = OlympianFactory(name='Billy', age=30, sex='M', weight=200)
 
     self.event1 = EventFactory()
     self.event2 = EventFactory()
@@ -91,6 +91,26 @@ class OlympianViewSet(TestCase):
           'total_medals_won': 0
         }
       ]
+    }
+
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(json_response, expected)
+
+  def test_happy_path_get_olympian_stats(self):
+    response = self.client.get('/api/v1/olympian_stats')
+
+    json_response = response.json()
+
+    expected = {
+      'olympian_stats': {
+        'total_competing_olympians': 3,
+        'average_weight': {
+          'unit': 'kg',
+          'male_olympians': 150.0,
+          'female_olympians': 150.5
+        },
+        'average_age': 23.7
+      }
     }
 
     self.assertEqual(response.status_code, 200)

--- a/api/views.py
+++ b/api/views.py
@@ -24,8 +24,8 @@ def _olympian_stats_payload(stats):
         'total_competing_olympians': stats['total_olympians'],
         'average_weight': {
           'unit': 'kg',
-          'male_olympians': stats['male_avg'],
-          'female_olympians': stats['female_avg']
+          'male_olympians': round(stats['male_avg'], 1),
+          'female_olympians': round(stats['female_avg'], 1)
         },
         'average_age': round(stats['avg_age'], 1)
       }

--- a/api/views.py
+++ b/api/views.py
@@ -1,10 +1,7 @@
-import json
-from django.shortcuts import render
-from django.http import JsonResponse, HttpResponse, QueryDict
+from django.http import JsonResponse
 from rest_framework.views import APIView
 from api.models import Olympian
 
-from django.db.models import Avg, Count, Q
 
 def _error_payload(error, code=400):
   return {
@@ -30,6 +27,7 @@ def _olympian_stats_payload(stats):
         'average_age': round(stats['avg_age'], 1)
       }
   }
+
 
 class OlympianList(APIView):
   def get(self, request):

--- a/api/views.py
+++ b/api/views.py
@@ -4,6 +4,7 @@ from django.http import JsonResponse, HttpResponse, QueryDict
 from rest_framework.views import APIView
 from api.models import Olympian
 
+from django.db.models import Avg, Count
 
 def _error_payload(error, code=400):
   return {
@@ -15,6 +16,19 @@ def _error_payload(error, code=400):
 def _olympians_payload(olympians):
   return {
       'olympians': olympians
+  }
+
+def _olympian_stats_payload(count, m_weight, f_weight, age):
+  return {
+      'olympian_stats': {
+        'total_competing_olympians': count,
+        'average_weight': {
+          'unit': 'kg',
+          'male_olympians': m_weight,
+          'female_olympians': f_weight
+        },
+        'average_age': age
+      }
   }
 
 class OlympianList(APIView):
@@ -29,5 +43,18 @@ class OlympianList(APIView):
     return JsonResponse(_olympians_payload(olympians), status=200)
 
 
+class OlympianStats(APIView):
+  def get(self, request):
 
+    #Need to calculate 4 things:
+    # total count of all olympians
+    count_avg = Olympian.objects.aggregate(Count('id'), Avg('age')) 
+    # average weight of all male olympians
+    male_weight = Olympian.objects.filter(sex='M').aggregate(Avg('weight'))
+    # average weight of all female olympians
+    female_weight = Olympian.objects.filter(sex='F').aggregate(Avg('weight'))
 
+    # then return it in the pre_built payload
+    import code; code.interact(local=dict(globals(), **locals()))
+     
+    return JsonResponse(_olympian_stats_payload(count_avg['id__count'], male_weight, female_weight, count_avg['id__count']), status=200)

--- a/olympic_analytics_tracker/urls.py
+++ b/olympic_analytics_tracker/urls.py
@@ -21,4 +21,5 @@ from api import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/olympians', views.OlympianList.as_view()),
+    path('api/v1/olympian_stats', views.OlympianStats.as_view())
 ]


### PR DESCRIPTION
## Description
- Create `GET api/v1/olympian_stats` endpoint that returns several statistics about all of the Olympians in a payload. 

Example response:
```
{
    "olympian_stats": {
        "total_competing_olympians": 2856,
        "average_weight": {
            "unit": "kg",
            "male_olympians": 79.4,
            "female_olympians": 62.7
        },
        "average_age": 26.4
    }
}
```

Completes User Story #1 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Unittest Results
- 100% - 10 tests passing
