### PR TITLE
Events Endpoint

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -10,6 +10,12 @@ def _olympian_payload(olympian):
       'total_medals_won': olympian.medal_count
   }
 
+def _event_sports_payload(sport, events):
+  return {
+      'sport': sport,
+      'events': [event.name for event in events]
+  }
+
 class Olympian(models.Model):
   GENDER = [
     ('M', 'Male'),
@@ -74,6 +80,18 @@ class Event(models.Model):
 
   def __str__(self):
     return self.name
+  
+  @classmethod
+  def all_sorted_by_sport(cls):
+    sports = Event.objects.values_list('sport', flat=True)
+    unique_sports = sorted(list(set(sports)))
+    sorted_events = []
+
+    for sport in unique_sports:
+      events = Event.objects.filter(sport=sport)
+      sorted_events.append(_event_sports_payload(sport, events))
+
+    return sorted_events
 
 
 class EventOlympian(models.Model):

--- a/api/tests/models/test_event.py
+++ b/api/tests/models/test_event.py
@@ -1,10 +1,34 @@
 from django.test import TestCase
+from ..factories import EventFactory
 from api.models import Event
 
 
 class EventModelTest(TestCase):
   def setUp(self):
-    self.event1 = Event.objects.create(name='event1', games='2016 Summer', sport='Badminton')
+    self.event1 = EventFactory(sport='Cycling')
+    self.event2 = EventFactory(sport='Archery')
+    self.event3 = EventFactory(sport='Archery')
 
   def test_string_representation(self):
     self.assertEqual(str(self.event1), self.event1.name)
+
+  def test_all_sorted_by_sport(self):
+    expected = [
+        {
+          'sport': 'Archery',
+          'events': [
+            self.event2.name,
+            self.event3.name,
+          ]
+        },
+        {
+          'sport': 'Cycling',
+          'events': [
+            self.event1.name,
+          ]
+        }
+    ]
+
+    self.assertEqual(Event.all_sorted_by_sport(), expected)
+
+

--- a/api/tests/views/test_event_views.py
+++ b/api/tests/views/test_event_views.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from ..factories import EventFactory
+
+
+class EventViewSet(TestCase):
+  def setUp(self):
+    self.event1 = EventFactory(sport='Cycling')
+    self.event2 = EventFactory(sport='Archery')
+    self.event3 = EventFactory(sport='Archery')
+
+  def test_happy_path_get_events_by_sport(self):
+    response = self.client.get('/api/v1/events')
+
+    json_response = response.json()
+
+    expected = {
+      'events':
+        [
+          {
+            'sport': 'Archery',
+            'events': [
+              self.event2.name,
+              self.event3.name,
+            ]
+          },
+          {
+            'sport': 'Cycling',
+            'events': [
+              self.event1.name,
+            ]
+          }
+        ]
+    }
+
+    self.assertEqual(json_response, expected)

--- a/api/views.py
+++ b/api/views.py
@@ -1,6 +1,6 @@
 from django.http import JsonResponse
 from rest_framework.views import APIView
-from api.models import Olympian
+from api.models import Olympian, Event
 
 
 def _error_payload(error, code=400):
@@ -13,6 +13,11 @@ def _error_payload(error, code=400):
 def _olympians_payload(olympians):
   return {
       'olympians': olympians
+  }
+
+def _events_payload(events):
+  return {
+      'events': events
   }
 
 def _olympian_stats_payload(stats):
@@ -46,3 +51,10 @@ class OlympianStats(APIView):
     olympian_stats = Olympian.olympian_stats()
      
     return JsonResponse(_olympian_stats_payload(olympian_stats), status=200)
+
+
+class EventList(APIView):
+  def get(self, request):
+    all_events = Event.all_sorted_by_sport()
+
+    return JsonResponse(_events_payload(all_events), status=200)

--- a/olympic_analytics_tracker/urls.py
+++ b/olympic_analytics_tracker/urls.py
@@ -21,5 +21,6 @@ from api import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/olympians', views.OlympianList.as_view()),
-    path('api/v1/olympian_stats', views.OlympianStats.as_view())
+    path('api/v1/olympian_stats', views.OlympianStats.as_view()),
+    path('api/v1/events', views.EventList.as_view())
 ]


### PR DESCRIPTION
## Description
- Create new `GET api/v1/events` endpoint that returns all event names sorted by their sport

Example response:
```
{
  "events":
    [
      {
        "sport": "Archery",
        "events": [
          "Archery Men's Individual",
          "Archery Men's Team",
          "Archery Women's Individual",
          "Archery Women's Team"
        ]
      },
      {
        "sport": "Badminton",
        "events": [
          "Badminton Men's Doubles",
          "Badminton Men's Singles",
          "Badminton Women's Doubles",
          "Badminton Women's Singles",
          "Badminton Mixed Doubles"
        ]
      },
      {...}
    ]
}
```

Closes #12 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Unittest Results
- 100% - 12 passing
