### PR TITLE
Event Medalists Endpoint

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -77,14 +77,14 @@ class Olympian(models.Model):
   @classmethod
   def medalists_by_event(cls, event_id):
     medals = ['Gold', 'Silver', 'Bronze']
-    
+
     olympians = Olympian.objects.filter(
         eventolympian__event_id=event_id
     ).annotate(
         medal=F('eventolympian__medal')
     ).filter(
       Q(medal__in=medals)
-    )
+    ).order_by('name')
 
     return [_event_medalists_payload(olympian) for olympian in olympians]
 

--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models import Count, Avg, Q, F
 
+
 def _olympian_payload(olympian):
   return {
       'name': olympian.name,

--- a/api/tests/models/test_olympian.py
+++ b/api/tests/models/test_olympian.py
@@ -88,16 +88,16 @@ class OlympianModelTest(TestCase):
   def test_medalists_by_event(self):
     expected = [
       {
-        'name': self.olympian1.name,
-        'team': self.olympian1.team,
-        'age': self.olympian1.age,
-        'medal': 'Bronze'
-      },
-      {
         'name': self.olympian2.name,
         'team': self.olympian2.team,
         'age': self.olympian2.age,
         'medal': 'Silver'
+      },
+      {
+        'name': self.olympian1.name,
+        'team': self.olympian1.team,
+        'age': self.olympian1.age,
+        'medal': 'Bronze'
       }
     ]
 

--- a/api/tests/models/test_olympian.py
+++ b/api/tests/models/test_olympian.py
@@ -76,7 +76,6 @@ class OlympianModelTest(TestCase):
     self.assertEqual(Olympian.youngest_oldest_olympian('oldest'), expected_oldest)
 
   def test_olympian_stats(self):
-
     expected = {
       'total_olympians': 3, 
       'avg_age': 23.666666666666668,
@@ -86,4 +85,20 @@ class OlympianModelTest(TestCase):
 
     self.assertEqual(Olympian.olympian_stats(), expected)
 
+  def test_medalists_by_event(self):
+    expected = [
+      {
+        'name': self.olympian1.name,
+        'team': self.olympian1.team,
+        'age': self.olympian1.age,
+        'medal': 'Bronze'
+      },
+      {
+        'name': self.olympian2.name,
+        'team': self.olympian2.team,
+        'age': self.olympian2.age,
+        'medal': 'Silver'
+      }
+    ]
 
+    self.assertEqual(Olympian.medalists_by_event(self.event2.id), expected)

--- a/api/tests/views/test_event_views.py
+++ b/api/tests/views/test_event_views.py
@@ -1,12 +1,25 @@
 from django.test import TestCase
-from ..factories import EventFactory
+from ..factories import EventFactory, OlympianFactory, EventOlympianFactory
 
 
 class EventViewSet(TestCase):
   def setUp(self):
+    self.olympian1 = OlympianFactory()
+    self.olympian2 = OlympianFactory()
+    self.olympian3 = OlympianFactory()
+    self.olympian4 = OlympianFactory()
+    self.olympian5 = OlympianFactory()
+
     self.event1 = EventFactory(sport='Cycling')
     self.event2 = EventFactory(sport='Archery')
     self.event3 = EventFactory(sport='Archery')
+
+    self.event_olympian1 = EventOlympianFactory(event=self.event1, olympian=self.olympian1, medal='NA')
+    self.event_olympian2 = EventOlympianFactory(event=self.event1, olympian=self.olympian2, medal='Bronze')
+    self.event_olympian3 = EventOlympianFactory(event=self.event1, olympian=self.olympian3, medal='Gold')
+    self.event_olympian4 = EventOlympianFactory(event=self.event1, olympian=self.olympian4, medal='Silver')
+
+    self.event_olympian5 = EventOlympianFactory(event=self.event2, olympian=self.olympian5, medal='Silver')
 
   def test_happy_path_get_events_by_sport(self):
     response = self.client.get('/api/v1/events')
@@ -29,6 +42,37 @@ class EventViewSet(TestCase):
               self.event1.name,
             ]
           }
+        ]
+    }
+
+    self.assertEqual(json_response, expected)
+
+  def test_happy_path_get_medalists_by_event(self):
+    response = self.client.get(f'/api/v1/events/{self.event1.id}/medalists')
+
+    json_response = response.json()
+
+    expected = {
+        'event': self.event1.name,
+        'medalists': [
+            {
+                'name': self.olympian3.name,
+                'team': self.olympian3.team,
+                'age': self.olympian3.age,
+                'medal': 'Gold'
+            },
+            {
+                'name': self.olympian4.name,
+                'team': self.olympian4.team,
+                'age': self.olympian4.age,
+                'medal': 'Silver'
+            },
+            {
+                'name': self.olympian2.name,
+                'team': self.olympian2.team,
+                'age': self.olympian2.age,
+                'medal': 'Bronze'
+            }
         ]
     }
 

--- a/api/tests/views/test_event_views.py
+++ b/api/tests/views/test_event_views.py
@@ -56,6 +56,12 @@ class EventViewSet(TestCase):
         'event': self.event1.name,
         'medalists': [
             {
+                'name': self.olympian2.name,
+                'team': self.olympian2.team,
+                'age': self.olympian2.age,
+                'medal': 'Bronze'
+            },
+            {
                 'name': self.olympian3.name,
                 'team': self.olympian3.team,
                 'age': self.olympian3.age,
@@ -66,12 +72,6 @@ class EventViewSet(TestCase):
                 'team': self.olympian4.team,
                 'age': self.olympian4.age,
                 'medal': 'Silver'
-            },
-            {
-                'name': self.olympian2.name,
-                'team': self.olympian2.team,
-                'age': self.olympian2.age,
-                'medal': 'Bronze'
             }
         ]
     }

--- a/api/tests/views/test_event_views.py
+++ b/api/tests/views/test_event_views.py
@@ -4,11 +4,11 @@ from ..factories import EventFactory, OlympianFactory, EventOlympianFactory
 
 class EventViewSet(TestCase):
   def setUp(self):
-    self.olympian1 = OlympianFactory()
-    self.olympian2 = OlympianFactory()
-    self.olympian3 = OlympianFactory()
-    self.olympian4 = OlympianFactory()
-    self.olympian5 = OlympianFactory()
+    self.olympian1 = OlympianFactory(name='Allie')
+    self.olympian2 = OlympianFactory(name='Holly')
+    self.olympian3 = OlympianFactory(name='Jim')
+    self.olympian4 = OlympianFactory(name='Sal')
+    self.olympian5 = OlympianFactory(name='Kate')
 
     self.event1 = EventFactory(sport='Cycling')
     self.event2 = EventFactory(sport='Archery')

--- a/api/tests/views/test_olympian_views.py
+++ b/api/tests/views/test_olympian_views.py
@@ -1,4 +1,3 @@
-import json
 from django.test import TestCase
 from ..factories import OlympianFactory, EventFactory, EventOlympianFactory
 

--- a/api/views.py
+++ b/api/views.py
@@ -20,6 +20,12 @@ def _events_payload(events):
       'events': events
   }
 
+def _medalists_payload(event, medalists):
+  return {
+      'event': event,
+      'medalists': medalists
+  }
+
 def _olympian_stats_payload(stats):
   return {
       'olympian_stats': {
@@ -58,3 +64,11 @@ class EventList(APIView):
     all_events = Event.all_sorted_by_sport()
 
     return JsonResponse(_events_payload(all_events), status=200)
+
+
+class EventMedalists(APIView):
+  def get(self, request, pk):
+    event_name = Event.objects.get(id=pk).name
+    medalists = Olympian.medalists_by_event(pk)
+
+    return JsonResponse(_medalists_payload(event_name, medalists), status=200)

--- a/olympic_analytics_tracker/urls.py
+++ b/olympic_analytics_tracker/urls.py
@@ -22,5 +22,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/olympians', views.OlympianList.as_view()),
     path('api/v1/olympian_stats', views.OlympianStats.as_view()),
-    path('api/v1/events', views.EventList.as_view())
+    path('api/v1/events', views.EventList.as_view()),
+    path('api/v1/events/<int:pk>/medalists', views.EventMedalists.as_view())
 ]


### PR DESCRIPTION
## Description
- Create new `GET api/v1/events/:id/medalists` endpoint that returns all medalists for a specified event

Example response:
```
{
  "event": "Badminton Mixed Doubles",
  "medalists": [
      {
        "name": "Tontowi Ahmad",
        "team": "Indonesia-1",
        "age": 29,
        "medal": "Gold"
      },
      {
        "name": "Chan Peng Soon",
        "team": "Malaysia",
        "age": 28,
        "medal": "Silver"
      }
    ]
}
```

Closes #13 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Unittest Results
- 100% - 14 passing tests
